### PR TITLE
fix(youtube): Prevent rebuilds from stream in Equatable props

### DIFF
--- a/lib/features/youtube/presentation/bloc/youtube_state.dart
+++ b/lib/features/youtube/presentation/bloc/youtube_state.dart
@@ -162,7 +162,6 @@ class YoutubeLoaded extends YoutubeState {
     expandedShelfKey,
     activeShelfKey,
     activeShelfBusy,
-    embeddingProgressStream,
   ];
 }
 


### PR DESCRIPTION
Closes #22

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `embeddingProgressStream` from `YoutubeLoaded.props` to prevent rebuild-triggering equality changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee967ce0df44351b0628a2c5660a762182d4833c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->