### PR TITLE
fix(embedding): Show previous check time instead of current time

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -219,12 +219,9 @@ function validateUserUpdate(data) {
 function validateEmbeddingProgressCacheData(data) {
   // Validate embedding progress cache structure
   let hasRequiredFields = data.keys().hasAll(['lastCheckedAt']);
-  let validTimestamp = data.lastCheckedAt is timestamp;
+  let validTimestamps = data.lastCheckedAt is timestamp
+    && (!data.keys().hasAny(['previousCheckedAt']) || data.previousCheckedAt is timestamp);
   
-  // Allow lastCheckedAt and any other fields (for merge operations)
-  // This allows Firestore merge operations to work properly
-  let validFields = data.lastCheckedAt is timestamp;
-  
-  return hasRequiredFields && validTimestamp && validFields;
+  return hasRequiredFields && validTimestamps;
 }
 

--- a/functions/main.py
+++ b/functions/main.py
@@ -1837,9 +1837,6 @@ def get_embedding_progress(req: https_fn.CallableRequest) -> dict:
             # Use previousCheckedAt for display (shows when counts were last fetched)
             if data and "previousCheckedAt" in data:
                 last_updated = data["previousCheckedAt"]
-            # Fallback to lastCheckedAt for first-time users
-            elif data and "lastCheckedAt" in data:
-                last_updated = data["lastCheckedAt"]
 
         return {
             "total": total,

--- a/functions/main.py
+++ b/functions/main.py
@@ -1831,11 +1831,15 @@ def get_embedding_progress(req: https_fn.CallableRequest) -> dict:
             .document("metadata")
             .get()
         )
-        last_checked = None
+        last_updated = None
         if cache_doc.exists:
             data = cache_doc.to_dict()
-            if data and "lastCheckedAt" in data:
-                last_checked = data["lastCheckedAt"]
+            # Use previousCheckedAt for display (shows when counts were last fetched)
+            if data and "previousCheckedAt" in data:
+                last_updated = data["previousCheckedAt"]
+            # Fallback to lastCheckedAt for first-time users
+            elif data and "lastCheckedAt" in data:
+                last_updated = data["lastCheckedAt"]
 
         return {
             "total": total,
@@ -1843,8 +1847,8 @@ def get_embedding_progress(req: https_fn.CallableRequest) -> dict:
             "pending": pending_count if pending_count >= 0 else 0,
             "failed": failed_count,
             "last_updated": (
-                last_checked.isoformat()
-                if last_checked
+                last_updated.isoformat()
+                if last_updated
                 else datetime.now(timezone.utc).isoformat()
             ),
         }

--- a/lib/features/youtube/data/repositories/youtube_repository_impl.dart
+++ b/lib/features/youtube/data/repositories/youtube_repository_impl.dart
@@ -469,7 +469,7 @@ class YoutubeRepositoryImpl implements YoutubeRepository {
     final user = _auth.currentUser;
     if (user == null) return;
 
-    // Read current lastCheckedAt to move it to previousCheckedAt
+    // Read current document to check if this is the first time
     final currentDoc = await _firestore
         .collection('users')
         .doc(user.uid)
@@ -477,16 +477,20 @@ class YoutubeRepositoryImpl implements YoutubeRepository {
         .doc('metadata')
         .get();
 
-    Map<String, dynamic> updateData = {
-      'lastCheckedAt': FieldValue.serverTimestamp(),
-    };
+    Map<String, dynamic> updateData = {};
 
-    // If there's a current lastCheckedAt, move it to previousCheckedAt
     if (currentDoc.exists && currentDoc.data() != null) {
       final currentData = currentDoc.data()!;
+      // If there's a current lastCheckedAt, move it to previousCheckedAt
       if (currentData['lastCheckedAt'] != null) {
         updateData['previousCheckedAt'] = currentData['lastCheckedAt'];
       }
+      // Always write new lastCheckedAt
+      updateData['lastCheckedAt'] = FieldValue.serverTimestamp();
+    } else {
+      // First time: write as previousCheckedAt (for display) and lastCheckedAt (for next time)
+      updateData['previousCheckedAt'] = FieldValue.serverTimestamp();
+      updateData['lastCheckedAt'] = FieldValue.serverTimestamp();
     }
 
     await _firestore

--- a/lib/features/youtube/data/repositories/youtube_repository_impl.dart
+++ b/lib/features/youtube/data/repositories/youtube_repository_impl.dart
@@ -469,13 +469,31 @@ class YoutubeRepositoryImpl implements YoutubeRepository {
     final user = _auth.currentUser;
     if (user == null) return;
 
+    // Read current lastCheckedAt to move it to previousCheckedAt
+    final currentDoc = await _firestore
+        .collection('users')
+        .doc(user.uid)
+        .collection('embeddingProgressCache')
+        .doc('metadata')
+        .get();
+
+    Map<String, dynamic> updateData = {
+      'lastCheckedAt': FieldValue.serverTimestamp(),
+    };
+
+    // If there's a current lastCheckedAt, move it to previousCheckedAt
+    if (currentDoc.exists && currentDoc.data() != null) {
+      final currentData = currentDoc.data()!;
+      if (currentData['lastCheckedAt'] != null) {
+        updateData['previousCheckedAt'] = currentData['lastCheckedAt'];
+      }
+    }
+
     await _firestore
         .collection('users')
         .doc(user.uid)
         .collection('embeddingProgressCache')
         .doc('metadata')
-        .set({
-          'lastCheckedAt': FieldValue.serverTimestamp(),
-        }, SetOptions(merge: true));
+        .set(updateData, SetOptions(merge: true));
   }
 }

--- a/lib/features/youtube/data/repositories/youtube_repository_impl.dart
+++ b/lib/features/youtube/data/repositories/youtube_repository_impl.dart
@@ -477,21 +477,29 @@ class YoutubeRepositoryImpl implements YoutubeRepository {
 
     await _firestore.runTransaction((transaction) async {
       final doc = await transaction.get(docRef);
+      final now = FieldValue.serverTimestamp();
       
       if (doc.exists && doc.data() != null) {
         final data = doc.data()!;
         final currentLastChecked = data['lastCheckedAt'];
         
-        // Move current lastCheckedAt to previousCheckedAt
-        transaction.update(docRef, {
-          'previousCheckedAt': currentLastChecked,
-          'lastCheckedAt': FieldValue.serverTimestamp(),
-        });
+        // Only move to previousCheckedAt if currentLastChecked is not null
+        if (currentLastChecked != null) {
+          transaction.update(docRef, {
+            'previousCheckedAt': currentLastChecked,
+            'lastCheckedAt': now,
+          });
+        } else {
+          // If no valid lastCheckedAt, just update lastCheckedAt
+          transaction.update(docRef, {
+            'lastCheckedAt': now,
+          });
+        }
       } else {
-        // First time: set both to current timestamp
+        // First time: set both to the same timestamp
         transaction.set(docRef, {
-          'previousCheckedAt': FieldValue.serverTimestamp(),
-          'lastCheckedAt': FieldValue.serverTimestamp(),
+          'previousCheckedAt': now,
+          'lastCheckedAt': now,
         });
       }
     });

--- a/lib/features/youtube/data/repositories/youtube_repository_impl.dart
+++ b/lib/features/youtube/data/repositories/youtube_repository_impl.dart
@@ -469,35 +469,31 @@ class YoutubeRepositoryImpl implements YoutubeRepository {
     final user = _auth.currentUser;
     if (user == null) return;
 
-    // Read current document to check if this is the first time
-    final currentDoc = await _firestore
+    final docRef = _firestore
         .collection('users')
         .doc(user.uid)
         .collection('embeddingProgressCache')
-        .doc('metadata')
-        .get();
+        .doc('metadata');
 
-    Map<String, dynamic> updateData = {};
-
-    if (currentDoc.exists && currentDoc.data() != null) {
-      final currentData = currentDoc.data()!;
-      // If there's a current lastCheckedAt, move it to previousCheckedAt
-      if (currentData['lastCheckedAt'] != null) {
-        updateData['previousCheckedAt'] = currentData['lastCheckedAt'];
+    await _firestore.runTransaction((transaction) async {
+      final doc = await transaction.get(docRef);
+      
+      if (doc.exists && doc.data() != null) {
+        final data = doc.data()!;
+        final currentLastChecked = data['lastCheckedAt'];
+        
+        // Move current lastCheckedAt to previousCheckedAt
+        transaction.update(docRef, {
+          'previousCheckedAt': currentLastChecked,
+          'lastCheckedAt': FieldValue.serverTimestamp(),
+        });
+      } else {
+        // First time: set both to current timestamp
+        transaction.set(docRef, {
+          'previousCheckedAt': FieldValue.serverTimestamp(),
+          'lastCheckedAt': FieldValue.serverTimestamp(),
+        });
       }
-      // Always write new lastCheckedAt
-      updateData['lastCheckedAt'] = FieldValue.serverTimestamp();
-    } else {
-      // First time: write as previousCheckedAt (for display) and lastCheckedAt (for next time)
-      updateData['previousCheckedAt'] = FieldValue.serverTimestamp();
-      updateData['lastCheckedAt'] = FieldValue.serverTimestamp();
-    }
-
-    await _firestore
-        .collection('users')
-        .doc(user.uid)
-        .collection('embeddingProgressCache')
-        .doc('metadata')
-        .set(updateData, SetOptions(merge: true));
+    });
   }
 }

--- a/lib/features/youtube/presentation/widgets/embedding_status_sheet.dart
+++ b/lib/features/youtube/presentation/widgets/embedding_status_sheet.dart
@@ -172,7 +172,7 @@ class _EmbeddingStatusSheetState extends State<EmbeddingStatusSheet> {
           const SizedBox(height: 4),
           Text(
             'Updated ${_formatDateTime(progress.lastUpdated!)}',
-            style: Theme.of(context).textTheme.titleMedium,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Colors.white),
           ),
         ],
         const SizedBox(height: 16),

--- a/lib/features/youtube/presentation/widgets/embedding_status_sheet.dart
+++ b/lib/features/youtube/presentation/widgets/embedding_status_sheet.dart
@@ -172,9 +172,7 @@ class _EmbeddingStatusSheetState extends State<EmbeddingStatusSheet> {
           const SizedBox(height: 4),
           Text(
             'Updated ${_formatDateTime(progress.lastUpdated!)}',
-            style: Theme.of(
-              context,
-            ).textTheme.bodySmall?.copyWith(color: Colors.grey[600]),
+            style: Theme.of(context).textTheme.titleMedium,
           ),
         ],
         const SizedBox(height: 16),

--- a/lib/features/youtube/presentation/widgets/embedding_status_sheet.dart
+++ b/lib/features/youtube/presentation/widgets/embedding_status_sheet.dart
@@ -37,8 +37,8 @@ class _EmbeddingStatusSheetState extends State<EmbeddingStatusSheet> {
           .read<YoutubeRepository>()
           .updateEmbeddingProgressLastChecked();
     } catch (e) {
-      // If timestamp update fails, still initialize the stream to avoid perpetual loading
-      if (mounted) {
+      // Only initialize stream if it wasn't already initialized
+      if (mounted && _progressStream == null) {
         setState(() {
           _progressStream = context
               .read<YoutubeRepository>()

--- a/lib/features/youtube/presentation/widgets/embedding_status_sheet.dart
+++ b/lib/features/youtube/presentation/widgets/embedding_status_sheet.dart
@@ -23,12 +23,7 @@ class _EmbeddingStatusSheetState extends State<EmbeddingStatusSheet> {
 
   Future<void> _initializeProgressStream() async {
     try {
-      // Update the last checked timestamp when modal opens
-      await context
-          .read<YoutubeRepository>()
-          .updateEmbeddingProgressLastChecked();
-
-      // Only start the stream after timestamp update completes
+      // Start the stream first to read the previous timestamp
       if (mounted) {
         setState(() {
           _progressStream = context
@@ -36,6 +31,11 @@ class _EmbeddingStatusSheetState extends State<EmbeddingStatusSheet> {
               .watchEmbeddingProgress();
         });
       }
+
+      // Update the timestamp for the next time after stream is started
+      await context
+          .read<YoutubeRepository>()
+          .updateEmbeddingProgressLastChecked();
     } catch (e) {
       // If timestamp update fails, still initialize the stream to avoid perpetual loading
       if (mounted) {

--- a/lib/features/youtube/presentation/widgets/embedding_status_sheet.dart
+++ b/lib/features/youtube/presentation/widgets/embedding_status_sheet.dart
@@ -172,7 +172,9 @@ class _EmbeddingStatusSheetState extends State<EmbeddingStatusSheet> {
           const SizedBox(height: 4),
           Text(
             'Updated ${_formatDateTime(progress.lastUpdated!)}',
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Colors.white),
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: Theme.of(context).colorScheme.onSurface,
+            ),
           ),
         ],
         const SizedBox(height: 16),


### PR DESCRIPTION
## Overview

Fixes the embedding progress modal to show the timestamp from the previous check instead of the current time when the button is clicked.

## Problem

The modal was showing 'Updated Just now' because it was reading the timestamp that was just written when the modal opened. This doesn't accurately reflect when the video counts were last updated.

## Solution

Reversed the order of operations:
1. Start the progress stream first (reads previous timestamp from backend)
2. Update the timestamp after stream starts (for next time)

## Changes

- **embedding_status_sheet.dart**: Modified  to start stream before updating timestamp
- Maintains all existing functionality while fixing the timestamp display logic

## Expected Behavior

- First click: Shows current time (no previous timestamp exists)
- Second click: Shows the timestamp from first click  
- Third click: Shows the timestamp from second click
- Accurately reflects when counts were 'last updated'

## Testing

- [x] Verify modal shows previous check time instead of current time
- [x] Ensure stream still works correctly with real-time updates
- [x] Test multiple clicks to verify timestamp progression

Closes #26

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Show the previous check time in the embedding progress modal by tracking `previousCheckedAt` and reading it for display.
> 
> - **Backend**
>   - **Cloud Functions**: `get_embedding_progress` now returns `last_updated` from `users/{uid}/embeddingProgressCache/metadata.previousCheckedAt` (fallback to now).
>   - **Firestore Rules**: `validateEmbeddingProgressCacheData` accepts optional `previousCheckedAt` (timestamp) alongside required `lastCheckedAt`.
> - **Client**
>   - **Repository**: `updateEmbeddingProgressLastChecked` uses a transaction to move `lastCheckedAt` to `previousCheckedAt` and set a new `lastCheckedAt`; on first write sets both.
>   - **UI**: Initialize progress stream before updating the timestamp so the modal shows the prior update time.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1853cf8fb78488bc807b8f0efc2e07aade546475. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->